### PR TITLE
Process Memory Isolation

### DIFF
--- a/kalloc.h
+++ b/kalloc.h
@@ -4,7 +4,7 @@
 #include "types.h"
 
 // Amount of reserved kernel pages
-#define KPAGES 1024 // ~4MO
+#define KPAGES 256 // ~1MO
 
 /**
  * Allocates a few pages for the kernel and initializes the kalloc's heap

--- a/sched.h
+++ b/sched.h
@@ -3,8 +3,9 @@
 
 #include "types.h"
 
-// Defines the size in Bytes of a program's stack
-#define STACK_SIZE 512 // ~10 func in stack depth and ~50 bytes per function
+// Defines the size in Pages of a program's stack
+#define STACK_PAGES 1
+#define STACK_SIZE STACK_PAGES * 4096
 
 /**
  * Enumerates a PCB's possible state
@@ -37,10 +38,10 @@ struct sched_pcb_s {
  *
  * @param C function pointer
  * @param C args
- * @param (UNUSED?) stack's size
+ * @param stack's size in pages
  * @param the success of the operation
  */
-bool sched_new_proc(func_t f, void *args, unsigned int stack_size);
+bool sched_new_proc(func_t f, void *args, unsigned int stack_pages);
 
 /**
  * Start the scheduler

--- a/vectors.s
+++ b/vectors.s
@@ -53,7 +53,7 @@ hang: b hang
 undefined:	 b undefined
 swi:	 b syscall_swi_handler
 prefetch:	b prefetch
-data:	 b data
+data:	 b vmem_data_handler
 unused:	b unused
 fiq:	b fiq
 

--- a/vmem.c
+++ b/vmem.c
@@ -1,5 +1,6 @@
 #include "vmem.h"
-#include "errno.h"
+#include "hw.h"
+#include "syscall.h"
 
 #define TT_ENTRY_SIZE 4
 #define FIRST_LVL_TT_COUN 4096
@@ -165,6 +166,22 @@ bool vmem_page_free(uint8* ptr, uint32 pages) {
     return true;
   }
   return false;
+}
+
+// Data Interrupt handler
+void vmem_data_handler() {
+  DISABLE_IRQ();
+
+  // DFSR Data Fault Status Register
+  // FAR Fault Address Register
+  unint8 dfs, fa;
+  __asm("MRC p15, 0, r0, c5, c0, 0"); // Copy DFSR -> r0
+  __asm("mov %0, r0" : "=r"(dfs)); // r0 -> dfs
+  __asm("MRC p15, 0, r0, c6, c0, 0"); // Copy FAR -> r0
+  __asm("mov %0, r0" : "=r"(fa)); // r0 -> fa
+
+  ENABLE_IRQ();
+  syscall_reboot();
 }
 
 // Emulates an MMU lookup without activating it: debugging tool

--- a/vmem.c
+++ b/vmem.c
@@ -174,7 +174,7 @@ void vmem_data_handler() {
 
   // DFSR Data Fault Status Register
   // FAR Fault Address Register
-  unint8 dfs, fa;
+  uint8 dfs, fa;
   __asm("MRC p15, 0, r0, c5, c0, 0"); // Copy DFSR -> r0
   __asm("mov %0, r0" : "=r"(dfs)); // r0 -> dfs
   __asm("MRC p15, 0, r0, c6, c0, 0"); // Copy FAR -> r0

--- a/vmem.h
+++ b/vmem.h
@@ -76,4 +76,9 @@ uint8* vmem_page_alloc(uint32 pages);
  */
 bool vmem_page_free(uint8* ptr, uint32 pages);
 
+/**
+ * Handles a data fault interrupt
+ */
+void vmem_data_handler();
+
 #endif


### PR DESCRIPTION
- [x] Handle data faults (report & reboot)
- [x] Replace `phyAlloc/kalloc` for `vmem`
- [ ] Manage memory isolation & vmem remapping
- [ ] Handle data faults by simple process termination instead of reboot